### PR TITLE
pin_c: allow passing --port_info option without --blif

### DIFF
--- a/pin_c/src/file_readers/pcf_reader.cpp
+++ b/pin_c/src/file_readers/pcf_reader.cpp
@@ -41,7 +41,7 @@ bool PcfReader::read_pcf(const string& f) {
       has_internal_pin = true;
     }
 
-    if (tr >= 3) ls << "(pcf line) " << line << endl;
+    if (tr >= 4) ls << "(pcf line) " << line << endl;
 
     if (has_internal_pin) {
       if (!(iss >> set_io_cmd >> user_pin >> bump_pin >> dash_mode >>
@@ -57,10 +57,9 @@ bool PcfReader::read_pcf(const string& f) {
       }
     }
 
-    if (tr >= 3) {
+    if (tr >= 4) {
       ls << "    user_pin:" << user_pin << "  bump_pin:" << bump_pin
-         << "  mode_name:" << mode_name;
-      ls << endl;
+         << "  mode_name:" << mode_name << endl;
     }
 
     commands_.emplace_back();


### PR DESCRIPTION
currently, pin_c aborts if --blif is missing. With this change, pin_c works of --port_info is specified instead of --blif
This is the 1s step for fixing EDA-812.

> ### Motivate of the pull request
> - [X ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Build compatibility
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
