### PR TITLE
if(n_l.encrypted) added

### DIFF
--- a/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.cpp
+++ b/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.cpp
@@ -751,7 +751,8 @@ AtomNetlist read_blif(e_circuit_format circuit_format,
 AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
                                   const char *blif_file,
                                   const t_model *user_models,
-                                  const t_model *library_models)
+                                  const t_model *library_models,
+                                  t_vpr_setup& vpr_setup)
 {
     AtomNetlist netlist;
     std::string netlist_id = vtr::secure_digest_file(blif_file);
@@ -777,6 +778,9 @@ AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
     else
     {
         // blif_error_wrap(alloc_callback, 0, "", "Could not open file '%s'.\n", blif_file);
+    }
+        if(n_l.encrypted){
+        vpr_setup.AnalysisOpts.gen_post_synthesis_netlist=false;
     }
 
     return netlist;

--- a/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.h
+++ b/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.h
@@ -16,6 +16,7 @@ AtomNetlist read_blif(e_circuit_format circuit_format,
 AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
                       const char* blif_file,
                       const t_model* user_models,
-                      const t_model* library_models);
+                      const t_model* library_models,
+                      t_vpr_setup& vpr_setup);
 
 #endif /*READ_BLIF_H*/

--- a/include/read_verilog/OpenFPGA/vpr/src/base/read_circuit.cpp
+++ b/include/read_verilog/OpenFPGA/vpr/src/base/read_circuit.cpp
@@ -62,7 +62,7 @@ AtomNetlist read_and_process_circuit(e_circuit_format circuit_format, t_vpr_setu
                 break;
             case e_circuit_format::VERILOG:
                 circuit_format = e_circuit_format::EBLIF;
-                netlist = read_blif_from_vrilog(circuit_format, circuit_file, user_models, library_models);
+                netlist = read_blif_from_vrilog(circuit_format, circuit_file, user_models, library_models,vpr_setup);
                 break;
             case e_circuit_format::FPGA_INTERCHANGE:
                 netlist = read_interchange_netlist(circuit_file, arch);

--- a/include/read_verilog/OpenFPGA11541/vpr/src/base/read_blif.cpp
+++ b/include/read_verilog/OpenFPGA11541/vpr/src/base/read_blif.cpp
@@ -743,7 +743,8 @@ AtomNetlist read_blif(e_circuit_format circuit_format,
 AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
                                   const char *blif_file,
                                   const t_model *user_models,
-                                  const t_model *library_models)
+                                  const t_model *library_models,
+                                  t_vpr_setup& vpr_setup)
 {
     AtomNetlist netlist;
     std::string netlist_id = vtr::secure_digest_file(blif_file);
@@ -769,6 +770,9 @@ AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
     else
     {
         // blif_error_wrap(alloc_callback, 0, "", "Could not open file '%s'.\n", blif_file);
+    }
+        if(n_l.encrypted){
+        vpr_setup.AnalysisOpts.gen_post_synthesis_netlist=false;
     }
 
     return netlist;

--- a/include/read_verilog/OpenFPGA11541/vpr/src/base/read_blif.h
+++ b/include/read_verilog/OpenFPGA11541/vpr/src/base/read_blif.h
@@ -16,6 +16,7 @@ AtomNetlist read_blif(e_circuit_format circuit_format,
 AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
                       const char* blif_file,
                       const t_model* user_models,
-                      const t_model* library_models);
+                      const t_model* library_models,
+                      t_vpr_setup& vpr_setup);
 
 #endif /*READ_BLIF_H*/

--- a/include/read_verilog/OpenFPGA11541/vpr/src/base/read_circuit.cpp
+++ b/include/read_verilog/OpenFPGA11541/vpr/src/base/read_circuit.cpp
@@ -62,7 +62,7 @@ AtomNetlist read_and_process_circuit(e_circuit_format circuit_format,
                 break;
             case e_circuit_format::VERILOG:
                 circuit_format = e_circuit_format::EBLIF;
-                netlist = read_blif_from_vrilog(circuit_format, circuit_file, user_models, library_models);
+                netlist = read_blif_from_vrilog(circuit_format, circuit_file, user_models, library_models,vpr_setup);
                 break;
             default:
                 VPR_FATAL_ERROR(VPR_ERROR_ATOM_NETLIST,


### PR DESCRIPTION
Condition of encrypted net-lists has been added in VPR to stop the dumping of net-lists from vpr if the verilog is encrypted.
