### PR TITLE
allow reading pin table csv with incomplete rows

### DIFF
--- a/pin_c/src/file_readers/rapidcsv.h
+++ b/pin_c/src/file_readers/rapidcsv.h
@@ -604,13 +604,14 @@ namespace rapidcsv
           }
           else
           {
-            const std::string errStr = "requested column index " +
-              std::to_string(columnIdx - (mLabelParams.mRowNameIdx + 1)) + " >= " +
-              std::to_string(itRow->size() - (mLabelParams.mRowNameIdx + 1)) +
-              " (number of columns on row index " +
-              std::to_string(std::distance(mData.begin(), itRow) -
-                             (mLabelParams.mColumnNameIdx + 1)) + ")";
-            throw std::out_of_range(errStr);
+            // -- disabled exception for now (for pin_c only).
+            //const std::string errStr = "requested column index " +
+            //  std::to_string(columnIdx - (mLabelParams.mRowNameIdx + 1)) + " >= " +
+            //  std::to_string(itRow->size() - (mLabelParams.mRowNameIdx + 1)) +
+            //  " (number of columns on row index " +
+            //  std::to_string(std::distance(mData.begin(), itRow) -
+            //                 (mLabelParams.mColumnNameIdx + 1)) + ")";
+            //throw std::out_of_range(errStr);
           }
         }
       }


### PR DESCRIPTION
> ### Motivate of the pull request
> - [x ] To address an existing issue. If so, please provide a link to the issue: <issue id>
Allow reading pin table csv with incomplete rows.
Currently, the csv reader throws exception because the number of fields on row 8285 (and below) is 3, but the number of columns in the header is 58.
Excel and LibreOffice can import such csv.

> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
Exception is throws by a third party readcsv.h
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
- disable exception throwing in readcsv.h
- resize the queried column vectors to have expected number of rows, this adds empty strings for missing fields.
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Build compatibility
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
