### PR TITLE
Finished EDA-1057 "Pin_c to use new columns from pin table".

### DIFF
--- a/pin_c/src/file_readers/pcf_reader.cpp
+++ b/pin_c/src/file_readers/pcf_reader.cpp
@@ -22,7 +22,7 @@ bool PcfReader::read_pcf(const string& f) {
 
   string line;
   bool has_error = false;
-  string set_io_cmd, user_pin, bump_pin, dash_mode, mode_name;
+  string set_io_cmd, user_pin, bump_or_ball_name, dash_mode, mode_name;
   string optional_dash_internal_pin, optional_internal_pin;
 
   while (std::getline(infile, line)) {
@@ -30,7 +30,7 @@ bool PcfReader::read_pcf(const string& f) {
     // set_io USER_PPIN BUMP_PIN_NAME -mode MODE_NAME
     set_io_cmd.clear();
     user_pin.clear();
-    bump_pin.clear();
+    bump_or_ball_name.clear();
     dash_mode.clear();
     mode_name.clear();
     optional_dash_internal_pin.clear();
@@ -44,13 +44,13 @@ bool PcfReader::read_pcf(const string& f) {
     if (tr >= 4) ls << "(pcf line) " << line << endl;
 
     if (has_internal_pin) {
-      if (!(iss >> set_io_cmd >> user_pin >> bump_pin >> dash_mode >>
+      if (!(iss >> set_io_cmd >> user_pin >> bump_or_ball_name >> dash_mode >>
             mode_name >> optional_dash_internal_pin >> optional_internal_pin)) {
         has_error = true;
         break;  // error
       }
     } else {
-      if (!(iss >> set_io_cmd >> user_pin >> bump_pin >> dash_mode >>
+      if (!(iss >> set_io_cmd >> user_pin >> bump_or_ball_name >> dash_mode >>
             mode_name)) {
         has_error = true;
         break;  // error
@@ -58,7 +58,7 @@ bool PcfReader::read_pcf(const string& f) {
     }
 
     if (tr >= 4) {
-      ls << "    user_pin:" << user_pin << "  bump_pin:" << bump_pin
+      ls << "    user_pin:" << user_pin << "  bump_or_ball_name:" << bump_or_ball_name
          << "  mode_name:" << mode_name << endl;
     }
 
@@ -67,7 +67,7 @@ bool PcfReader::read_pcf(const string& f) {
 
     cur_command.push_back(set_io_cmd);
     cur_command.push_back(user_pin);
-    cur_command.push_back(bump_pin);
+    cur_command.push_back(bump_or_ball_name);
     cur_command.push_back(dash_mode);
     cur_command.push_back(mode_name);
 

--- a/pin_c/src/file_readers/rapid_csv_reader.h
+++ b/pin_c/src/file_readers/rapid_csv_reader.h
@@ -28,7 +28,8 @@ class RapidCsvReader {
     BCD() noexcept = default;
   };
 
-  RapidCsvReader() = default;
+  RapidCsvReader();
+  ~RapidCsvReader();
 
   // file i/o
   bool read_csv(const std::string& f, bool check);
@@ -38,8 +39,9 @@ class RapidCsvReader {
   bool sanity_check(const rapidcsv::Document& doc) const;
 
   // data query
-  XYZ get_pin_xyz_by_bump_name(const string& mode, const string& bump_name,
-                               const string& gbox_pin_name) const;
+  XYZ get_pin_xyz_by_name(const string& mode,
+                          const string& bump_or_ball_name,
+                          const string& gbox_pin_name) const;
 
   uint numRows() const noexcept {
     assert(bcd_.size() == gbox_name_.size());
@@ -47,18 +49,16 @@ class RapidCsvReader {
     return bcd_.size();
   }
 
-  bool has_io_pin(const string& pin_name) const noexcept {
-    assert(!bcd_.empty());
-    for (const BCD& x : bcd_) {
-      if (x.bumpB_ == pin_name)
-        return true;
-    }
-    return false;
-  }
+  bool has_io_pin(const string& pin_name) const noexcept;
 
   const string& bumpPinName(uint row) const noexcept {
     assert(row < bcd_.size());
     return bcd_[row].bumpB_;
+  }
+
+  const string& ballPinName(uint row) const noexcept {
+    assert(row < bcd_.size());
+    return bcd_[row].ballNameC_;
   }
 
   int get_pin_x_by_pin_idx(uint i) const noexcept {
@@ -86,6 +86,8 @@ class RapidCsvReader {
     return fitr->second;
   }
 
+  string bumpName2BallName(const string& bump_name) const noexcept;
+
  private:
   std::map<string, vector<string>> modes_map_;
 
@@ -104,6 +106,8 @@ class RapidCsvReader {
   vector<XYZ> io_tile_pin_xyz_;  // "IO_tile_pin_x", "_y", "_z"
 
   int start_position_ = 0;  // "GBX GPIO" group start position in pin table row
+
+  bool use_bump_column_B_ = false;  // old mode for EDA-1057
 
   friend class pin_location;
 };

--- a/pin_c/src/pin_loc/pin_location.h
+++ b/pin_c/src/pin_loc/pin_location.h
@@ -44,7 +44,7 @@ class pin_location {
     MAX_MESSAGE_ID
   };
 
-  string error_messages[MAX_MESSAGE_ID] = {
+  const char* error_messages_[MAX_MESSAGE_ID] = {
       "Missing input or output file arguments",  // MISSING_IN_OUT_FILES
       "Pin location file parse error",           // PIN_LOC_XML_PARSE_ERROR
       "Pin map file parse error",                // PIN_MAP_CSV_PARSE_ERROR
@@ -125,11 +125,11 @@ class pin_location {
   bool generate_csv_file_for_os_flow();
   bool read_csv_file(RapidCsvReader&);
   bool read_user_design();
-  bool read_user_pinloc_constrain_file();
+  bool read_pcf_file();
 
-  bool create_place_file(RapidCsvReader&);
+  bool create_place_file(const RapidCsvReader&);
 
-  bool create_temp_pcf_file(RapidCsvReader& rs_csv_rd);
+  bool create_temp_pcf_file(const RapidCsvReader& csv_rd);
 
   static void shuffle_candidates(vector<int>& v);
 
@@ -141,7 +141,7 @@ class pin_location {
 
   bool convert_pcf_file_for_os_flow(string pcf_file_name);
 
-  bool get_available_bump_pin(const RapidCsvReader& rs_csv_rd,
+  bool get_available_bump_pin(const RapidCsvReader& csv_rd,
                               std::pair<string, string>& bump_pin_and_mode,
                               PortDirection port_direction);
 


### PR DESCRIPTION
New mode is currently disabled. To enable, change true to false in rapid_csv_reader.cpp line 38:
38   use_bump_column_B_ = true; // change use_bump_column_B_ to false to start using ball name column.

> ### Motivate of the pull request
> - [X ] To address an existing issue. If so, please provide a link to the issue: EDA-1057
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
New mode is currently disabled. To enable, change true to false in rapid_csv_reader.cpp line 38:
38   use_bump_column_B_ = true; // change use_bump_column_B_ to false to start using ball name column.
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Build compatibility
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
