### PR TITLE
EDA-1057: added support for using ball_ID (PT column D) in pcf.

### DIFF
--- a/pin_c/src/file_readers/rapid_csv_reader.h
+++ b/pin_c/src/file_readers/rapid_csv_reader.h
@@ -22,7 +22,7 @@ class RapidCsvReader {
     // --- 1-B  Bump/Pin Name
     // --- 2-C  Ball Name
     // --- 3-D  Ball ID
-    string bumpB_, ballNameC_, ball_ID_;
+    string bump_, ball_, ball_ID_;
     int row_ = 0;
 
     BCD() noexcept = default;
@@ -40,7 +40,7 @@ class RapidCsvReader {
 
   // data query
   XYZ get_pin_xyz_by_name(const string& mode,
-                          const string& bump_or_ball_name,
+                          const string& bump_ball_or_ID,
                           const string& gbox_pin_name) const;
 
   uint numRows() const noexcept {
@@ -49,16 +49,16 @@ class RapidCsvReader {
     return bcd_.size();
   }
 
-  bool has_io_pin(const string& pin_name) const noexcept;
+  bool has_io_pin(const string& pin_name_or_ID) const noexcept;
 
   const string& bumpPinName(uint row) const noexcept {
     assert(row < bcd_.size());
-    return bcd_[row].bumpB_;
+    return bcd_[row].bump_;
   }
 
   const string& ballPinName(uint row) const noexcept {
     assert(row < bcd_.size());
-    return bcd_[row].ballNameC_;
+    return bcd_[row].ball_;
   }
 
   int get_pin_x_by_pin_idx(uint i) const noexcept {
@@ -76,14 +76,14 @@ class RapidCsvReader {
     return io_tile_pin_xyz_[i].z_;
   }
 
-  vector<string> getModeData(const string& mode_name) const noexcept {
+  const vector<string>* getModeData(const string& mode_name) const noexcept {
     assert(!mode_name.empty());
     if (mode_name.empty())
-      return {};
+      return nullptr;
     auto fitr = modes_map_.find(mode_name);
     if (fitr == modes_map_.end())
-      return {};
-    return fitr->second;
+      return nullptr;
+    return &(fitr->second);
   }
 
   string bumpName2BallName(const string& bump_name) const noexcept;
@@ -112,9 +112,9 @@ class RapidCsvReader {
   friend class pin_location;
 };
 
-inline std::ostream& operator<<(std::ostream& os, const RapidCsvReader::BCD& p) {
-  os << "(bcd  " << p.bumpB_ << "  " << p.ballNameC_
-     << "  " << p.ball_ID_ << "  row:" << p.row_ << ')';
+inline std::ostream& operator<<(std::ostream& os, const RapidCsvReader::BCD& b) {
+  os << "(bcd  " << b.bump_ << "  " << b.ball_
+     << "  " << b.ball_ID_ << "  row:" << b.row_ << ')';
   return os;
 }
 


### PR DESCRIPTION
Now pin_c matches pcf commands with both ball-name and ball-ID, for example, the following pcf lines are now equivalent for pin_c:
  set_io a HR_1_21_10N -mode Mode_BP_SDR_A_RX
  set_io a N23 -mode Mode_BP_SDR_A_RX

> ### Motivate of the pull request
> - [X ] To address an existing issue. If so, please provide a link to the issue: EDA-1057
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
Now pin_c matches pcf commands with both ball-name and ball-ID, for example, the following pcf lines are now equivalent for pin_c:
  set_io a HR_1_21_10N -mode Mode_BP_SDR_A_RX
  set_io a N23 -mode Mode_BP_SDR_A_RX
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Build compatibility
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
