### PR TITLE
EDA-1057: enabled new mode (columns C and D in pin-table).

### DIFF
--- a/pin_c/src/file_readers/rapid_csv_reader.cpp
+++ b/pin_c/src/file_readers/rapid_csv_reader.cpp
@@ -35,7 +35,7 @@ static inline string label_column(int i) noexcept
 RapidCsvReader::RapidCsvReader()
 {
   // old mode for EDA-1057
-  use_bump_column_B_ = true; // true - old mode, false - new mode
+  use_bump_column_B_ = false; // true - old mode, false - new mode
   if (getenv("pinc_use_bump_column_B")) {
     use_bump_column_B_ = true;
     if (ltrace())


### PR DESCRIPTION
It's possible use the old mode by env variable:
export pinc_use_bump_column_B=1

> ### Motivate of the pull request
> - [ X] To address an existing issue. If so, please provide a link to the issue: EDA-1057
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
It's possible use the old mode by env variable:
export pinc_use_bump_column_B=1
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [ ] technical details about limitation  -->
> <!-- - [ ] more limitations  -->
>
> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- This PR improves in the following aspects: -->
> <!-- - [ ] details about the technical highlight -->
> <!-- - [ ] <more technical highlights -->

> ### Which part of the code base require a change
> <!-- In general, modification on existing submodules are not acceptable. You should push changes to upstream. -->
> - [ ] Build compatibility
> - [ ] Documentation
> - [ ] Regression tests
> - [ ] Continous Integration (CI) scripts

> ### Impact of the pull request

> - [ ] Require a change on Quality of Results (QoR)
> - [ ] Break back-compatibility. If so, please list who may be influenced.
