### PR TITLE
pin_c: turn off LTO to fix linker issue

### DIFF
--- a/pin_c/CMakeLists.txt
+++ b/pin_c/CMakeLists.txt
@@ -16,6 +16,7 @@ if (PRODUCTION_BUILD)
     message("Production Build type set to ON")
     set (PRODUCTION_BUILD_FLAG "-DPRODUCTION_BUILD=1")
     add_definitions(-DPRODUCTION_BUILD)
+    set(CXX_OPTS "-fPIC;-O2;-pipe;-mavx")
     message("FLEX: "  ${FLEX_LM_SRC_DIR})
 endif(PRODUCTION_BUILD)
 
@@ -81,6 +82,9 @@ set_target_properties(blif_parse_static PROPERTIES
 target_link_libraries(libpinconst PUBLIC blif_parse_static vprst_static libvtrutil libpugixml)
 
 add_executable(pin_c ${EXEC_SOURCES})
+
+set_target_properties(pin_c libpinconst PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
+
 if(PRODUCTION_BUILD)
     target_link_libraries(pin_c PUBLIC libpinconst 
                                        blif_parse_static
@@ -101,16 +105,17 @@ else()
                                        libreadedif
                                        ${OPENSSL_LIBRARIES})
 endif()
-#Supress IPO link warnings if IPO is enabled
-get_target_property(PIN_C_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
-if (PIN_C_USES_IPO)
-    set_target_properties(vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
+
+##Supress IPO link warnings if IPO is enabled
+#get_target_property(PIN_C_USES_IPO vpr INTERPROCEDURAL_OPTIMIZATION)
+#if (PIN_C_USES_IPO)
+#    set_target_properties(vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+#endif()
 
 #
 # PIN_C compiler options
 #
-target_compile_options(pin_c PRIVATE -Werror -Wall)
+target_compile_options(pin_c PRIVATE -Werror -Wall -fPIC -O2 -pipe -mavx)
 
 #
 # Profile Guilded Optimization Configuration
@@ -138,12 +143,13 @@ add_dependencies(test_pin_c pin_c)
 add_dependencies(pin_c vprst_static)
 add_dependencies(pin_c blif_parse_static)
 
+set_target_properties(pin_c libpinconst test_pin_c PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
-#Supress IPO link warnings if IPO is enabled
-get_target_property(TEST_PIN_C_USES_IPO pin_c INTERPROCEDURAL_OPTIMIZATION)
-if (TEST_PIN_C_USES_IPO)
-    set_target_properties(test_vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
-endif()
+##Supress IPO link warnings if IPO is enabled
+#get_target_property(TEST_PIN_C_USES_IPO pin_c INTERPROCEDURAL_OPTIMIZATION)
+#if (TEST_PIN_C_USES_IPO)
+#    set_target_properties(test_vpr PROPERTIES LINK_FLAGS ${IPO_LINK_WARN_SUPRESS_FLAGS})
+#endif()
 
 add_test(NAME test_vpr
     COMMAND test_vpr --use-colour=yes

--- a/pin_c/src/pin_loc/pin_location.cpp
+++ b/pin_c/src/pin_loc/pin_location.cpp
@@ -7,7 +7,6 @@
 #include "pin_location.h"
 
 #include <random>
-#include <regex>
 #include <set>
 
 #include "blif_reader.h"
@@ -1001,9 +1000,6 @@ bool pin_location::create_temp_pcf_file(const RapidCsvReader& csv_rd) {
 
   string pinName, set_io_str;
 
-  static std::regex addr_RE(R"(a_address)");
-  static std::regex data_RE(R"(a_data)");
-
   if (tr >= 2) {
     lprintf("--- writing pcf inputs (%u)\n", input_sz);
   }
@@ -1011,12 +1007,6 @@ bool pin_location::create_temp_pcf_file(const RapidCsvReader& csv_rd) {
     const string& inpName = user_design_inputs_[i];
     if (tr >= 4) {
       lprintf("assigning user_design_input #%u %s\n", i, inpName.c_str());
-      if (std::regex_search(inpName, addr_RE)) {
-        lputs2("\t  ^^^  XXX addr_RE MATCH");
-      }
-      if (std::regex_search(inpName, data_RE)) {
-        lputs2("\t  ^^^  XXX data_RE MATCH");
-      }
       if (csv_rd.hasCustomerInternalName(inpName)) {
         lprintf("\t (CustIntName) hasCustomerInternalName( %s )\n",
                 inpName.c_str());


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
Fix gcc "link time compilation" internal error (gcc bug).
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
Fix gcc "link time compilation" internal error (gcc bug).
Linking CXX executable ../../pin_c/pin_c
during IPA pass: icf
lto1: internal compiler error: Segmentation fault
0x9db587 crash_signal
      ../../src/gcc/toplev.c:327
0x7f023cd0851f ???

