### PR TITLE
EDA-606: Improve error message from pin_c

### DIFF
--- a/pin_c/src/file_readers/rapid_csv_reader.cpp
+++ b/pin_c/src/file_readers/rapid_csv_reader.cpp
@@ -488,7 +488,7 @@ void RapidCsvReader::print_csv() const {
   ls << "#row\tBump/Pin Name \t Customer Name \t Ball ID "
      << "\t IO_tile_pin\t IO_tile_pin_x\tIO_tile_pin_y\tIO_tile_pin_z"
      << " \t Customer Internal Name" << endl;
-  string dash = strReplicate('-', 139u);
+  string dash = sReplicate('-', 139u);
   ls << dash << endl;
 
   uint num_rows = numRows();

--- a/pin_c/src/pin_loc/pin_location.h
+++ b/pin_c/src/pin_loc/pin_location.h
@@ -23,7 +23,7 @@ using std::vector;
 
 class pin_location {
 
-  enum { ASSIGN_IN_RANDOM = 0, ASSIGN_IN_DEFINE_ORDER } pin_assign_method_;
+  enum { ASSIGN_IN_RANDOM = 0, ASSIGN_IN_DEFINE_ORDER = 1 } pin_assign_method_ = ASSIGN_IN_DEFINE_ORDER;
 
   cmd_line cl_;
 
@@ -72,7 +72,10 @@ class pin_location {
     }
   };
 
-  pin_location(const cmd_line& cl);
+  pin_location(const cmd_line& cl)
+   : cl_(cl) {
+    pin_assign_method_ = ASSIGN_IN_DEFINE_ORDER;
+  }
   ~pin_location();
 
   const cmd_line& get_cmd() const noexcept { return cl_; }

--- a/pin_c/src/util/pinc_log.cpp
+++ b/pin_c/src/util/pinc_log.cpp
@@ -22,20 +22,85 @@ void set_ltrace(int t) noexcept {
   s_logLevel = t;
 }
 
+#define LPUT if (cs && cs[0]) cout << cs;
+#define LEND cout << endl; fflush(stdout);
+
 void lputs(const char* cs) noexcept {
-  if (cs && cs[0]) cout << cs;
-  cout << endl;
+    LPUT
+    LEND
+}
+
+void lputs0(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs1(const char* cs) noexcept {
+    LPUT
+    LEND
 }
 void lputs2(const char* cs) noexcept {
-  if (cs && cs[0]) cout << cs;
-  cout << endl;
+    LPUT
+    LEND
 }
-void lputs(const std::string& s) noexcept {
-  if (s.empty()) {
+void lputs3(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs4(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs5(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs6(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs7(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs8(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputs9(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+void lputsX(const char* cs) noexcept {
+    LPUT
+    LEND
+}
+
+void lputs(const string& s) noexcept {
+  if (s.empty())
     cout << endl;
-  } else {
+  else
     lputs(s.c_str());
-  }
+}
+
+static constexpr char q = '\'';
+void bh1(const char* fn, int l, const char* s) noexcept {
+  if (!s) return;
+  cout << "\n bh1: " << fn << ':' << l << q << s << q << endl;
+}
+void bh2(const char* fn, int l, const char* s) noexcept {
+  if (!s) return;
+  cout << "\n bh2: " << fn << ':' << l << q << s << q << endl;
+}
+void bh3(const char* fn, int l, const char* s) noexcept {
+  if (!s) return;
+  cout << "\n bh3: " << fn << ':' << l << q << s << q << endl;
+}
+
+void flush_out(bool nl) noexcept {
+  if (nl)
+    cout << endl;
+  cout.flush();
+  fflush(stdout);
 }
 
 void lprintf(const char* format, ...) {
@@ -56,7 +121,7 @@ void lprintf(const char* format, ...) {
   }
 }
 
-string strToLower(const string& s) noexcept {
+string sToLower(const string& s) noexcept {
   if (s.empty()) return {};
   const char* cs = s.c_str();
   if (!cs || !cs[0]) return {};
@@ -67,12 +132,27 @@ string strToLower(const string& s) noexcept {
   return result;
 }
 
-string strReplicate(char c, uint num) noexcept {
-  if (!num || num > 48000) return {};
-  char buf[num + 1];
-  buf[num] = 0;
-  for (uint i = 0; i < num; i++) buf[i] = c;
-  return string(buf);
+string sToUpper(const string& s) noexcept {
+  if (s.empty()) return {};
+  const char* cs = s.c_str();
+  if (!cs || !cs[0]) return {};
+
+  string result;
+  result.reserve(s.length() + 1);
+  for (const char* p = cs; *p; p++) result.push_back(std::toupper(*p));
+  return result;
+}
+
+string sReplicate(char c, uint num) noexcept {
+  constexpr uint num_lim = INT_MAX;
+  assert(num < num_lim);
+  if (!num || num > num_lim) return {};
+
+  string result;
+  result.reserve(num + 1);
+  result.insert(result.end(), num, c);
+
+  return result;
 }
 
 }  // namespace pinc

--- a/pin_c/src/util/pinc_log.h
+++ b/pin_c/src/util/pinc_log.h
@@ -1,10 +1,24 @@
+//
 // logging and debug tracing
+//
+//   lprintf : log-printf
+//     lputs : log-puts
+//      lout : replaces cout, will print to both stdout and logfile
+//
+//  currently, log- functions just print on stdout, real logfile can be added later
+//
+//  lputs<Number> functions are equivalent to lputs(),
+//  there are convenient "anchor points" for setting temporary breakpoints.
+//
+//  bh<Number> are similar to lputs<Number>, only they can be silent,
+//             and can indicate __FILE__,__LINE__
+//  "BH" stands for Break Here, inspired by purify_stop_here().
+//
 #pragma once
 #ifndef __rs_PINC_LOG_H_
 #define __rs_PINC_LOG_H_
 
 #include <inttypes.h>
-#include <strings.h>
 
 #include <algorithm>
 #include <cassert>
@@ -16,13 +30,13 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <fstream>
-#include <iomanip>
 #include <iostream>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <numeric>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <functional>
@@ -37,20 +51,43 @@ namespace pinc {
 uint16_t ltrace() noexcept;
 void set_ltrace(int t) noexcept;
 
-// log-printf, log-puts, lout
-// currently, log- functions just print on cout, real logfile can be added later
 void lprintf(const char* format, ...) __attribute__((format(printf, 1, 2)));
-void lputs(const char* cs = nullptr) noexcept;
-void lputs2(const char* cs = nullptr) noexcept;
+void lputs(const char* cs = 0) noexcept;
+void lputs0(const char* cs = 0) noexcept;
+void lputs1(const char* cs = 0) noexcept;
+void lputs2(const char* cs = 0) noexcept;
+void lputs3(const char* cs = 0) noexcept;
+void lputs4(const char* cs = 0) noexcept;
+void lputs5(const char* cs = 0) noexcept;
+void lputs6(const char* cs = 0) noexcept;
+void lputs7(const char* cs = 0) noexcept;
+void lputs8(const char* cs = 0) noexcept;
+void lputs9(const char* cs = 0) noexcept;
+void lputsX(const char* cs = 0) noexcept;
 void lputs(const std::string& s) noexcept;
+
+void bh1(const char* fn, int l, const char* s=0) noexcept;
+void bh2(const char* fn, int l, const char* s=0) noexcept;
+void bh3(const char* fn, int l, const char* s=0) noexcept;
+
+void flush_out(bool nl = false) noexcept;
+
 inline std::ostream& lout() noexcept { return std::cout; }
 
-std::string strToLower(const std::string& s) noexcept;
+std::string sToLower(const std::string& s) noexcept;
+std::string sToUpper(const std::string& s) noexcept;
 
-std::string strReplicate(char c, uint num) noexcept;
-inline std::string strSpace(uint num) noexcept {
-  return strReplicate(' ', num);
+inline std::string sToLower(const char* cs) noexcept {
+    std::string e;
+    return (cs && *cs) ? sToLower(std::string(cs)) : e;
 }
+inline std::string sToUpper(const char* cs) noexcept {
+    std::string e;
+    return (cs && *cs) ? sToUpper(std::string(cs)) : e;
+}
+
+std::string sReplicate(char c, uint num) noexcept;
+inline std::string sSpace(uint num) noexcept { return sReplicate(' ', num); }
 
 template <typename T>
 inline void logArray(const T* A, size_t n, const char* prefix) noexcept {


### PR DESCRIPTION
> ### Motivate of the pull request
> - [X ] To address an existing issue. If so, please provide a link to the issue: EDA-606
> - [ ] Breaking new feature. If so, please describe details in the description part.


> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->

When the user design has more IO pins than device can supply, pin_c now prints this:

pin_c ERROR: failed getting device pin for input pin: s0_haddr_15_i

[Error] Too many input pins
  design has 477 input pins
  design has 131 output pins

pin_c does not print the number of device pins currently, because pin assignment also depends on modes.
I will include the device pins and modes later, in the next release. The info on the device pins is static and can be documented each time we update the pin table.

