### PR TITLE
[EDA-1207] stars: add --analysis option to prevent vpr from running the packer

### DIFF
--- a/stars/src/main.cpp
+++ b/stars/src/main.cpp
@@ -3,16 +3,35 @@
 #include "sta_file_writer.h"
 #include "vpr_main.h"
 
+#include <cstring>
+
 int main(int argc, const char *argv[]) {
 
   // run status
   bool status = true;
 
-  // 0. call vpr to build design context
   std::cout << "STARS: Preparing design data ... " << std::endl;
-  vpr::vpr(argc, (char **)argv);
 
-  // 1. write files for opensta
+  // 1. add --analysis option if missing:
+  char** vprArgv = (char**) calloc(argc + 4, sizeof(char*));
+  int vprArgc = argc;
+  bool found_analysis = false;
+  std::string analysis = "--analysis";
+  for (int i = 0; i < argc; i++) {
+    const char* a = argv[i];
+    if (analysis == a) found_analysis = true;
+    vprArgv[i] = strdup(a);
+  }
+  if (not found_analysis) {
+    std::cout << "STARS: added --analysis to options" << std::endl;
+    vprArgv[argc] = strdup("--analysis");
+    vprArgc++;
+  }
+
+  // 2. call vpr to build design context
+  vpr::vpr(vprArgc, vprArgv);
+
+  // 3. write files for opensta
   std::cout << "STARS: Creating sta files ... " << std::endl;
   if (!stars::create_sta_files(argc, argv)) {
     std::cerr << "STARS: Creating sta files failed." << std::endl;


### PR DESCRIPTION

> ### Motivate of the pull request
> - [ X] To address an existing issue. If so, please provide a link to the issue: EDA-1207
> - [ ] Breaking new feature. If so, please describe details in the description part.

> ### Describe the technical details
> #### What is currently done? (Provide issue link if applicable)
> <!-- Please provide a list of limitations if not specified in any issue -->
> <!-- Below is a template, uncomment upon your needs -->
> <!-- Currently, the project has the following limitations: -->
> <!-- - [X ] technical details about limitation  -->
currently, when VPR code is called from stars for timing graph creation, it re-runs the packer,
which wastes significant runtime, since packing is not needed at this stage.
> <!-- - [ ] more limitations  -->

> #### What does this pull request change?
> <!-- Please provide a list of highlights of your changes. -->
This change adds --analysis  VPR-option before calling VPR from stars, it prevents re-running the packer.

