### PR TITLE
pin_c: temporarily restore blif support (obsolete feature)

### DIFF
--- a/pin_c/src/file_readers/blif_reader.cpp
+++ b/pin_c/src/file_readers/blif_reader.cpp
@@ -1,0 +1,105 @@
+#include "vtr_path.h"
+#include "read_blif.h"
+
+#include "blifparse.hpp"
+
+#include "file_readers/blif_reader.h"
+
+namespace pinc {
+
+// blif parser callback
+ using namespace blifparse;
+ class BlifParserCallback : public blifparse::Callback {
+    int lineno_ = -1;
+    e_circuit_format circuit_format = e_circuit_format::BLIF;
+     public:
+         BlifParserCallback(e_circuit_format circuit_format_) : circuit_format(circuit_format_) {}
+         void start_parse() override {}
+
+         void filename(std::string /*fname*/) override {}
+         void lineno(int /*line_num*/) override {}
+
+         void begin_model(std::string /*model_name*/) override {}
+         void inputs(std::vector<std::string> input_ports) override {
+             for (auto input_port : input_ports) {
+                 inputs_.push_back(input_port);
+             }
+         }
+         void outputs(std::vector<std::string> output_ports) override {
+             for (auto output_port : output_ports) {
+                 outputs_.push_back(output_port);
+             }
+         }
+
+         void names(std::vector<std::string> /*nets*/, std::vector<std::               vector<LogicValue>> /*so_cover*/) override {}
+         void latch(std::string /*input*/, std::string /*output*/, LatchType /*        type*/, std::string /*control*/,            LogicValue /*init*/) override {}
+         void subckt(std::string /*model*/, std::vector<std::string> /*ports*/, std::  vector<std::string> /*nets*/)         override {}
+         void blackbox() override {}
+
+         //BLIF Extensions
+    void conn(std::string src, std::string dst) override {
+        if (circuit_format != e_circuit_format::EBLIF) {
+            parse_error(lineno_, ".conn", "Supported only in extended BLIF format");
+        }
+    }
+
+    void cname(std::string cell_name) override {
+        if (circuit_format != e_circuit_format::EBLIF) {
+            parse_error(lineno_, ".cname", "Supported only in extended BLIF format");
+        }
+    }
+
+    void attr(std::string name, std::string value) override {
+        if (circuit_format != e_circuit_format::EBLIF) {
+            parse_error(lineno_, ".attr", "Supported only in extended BLIF format");
+        }
+    }
+
+    void param(std::string name, std::string value) override {
+        if (circuit_format != e_circuit_format::EBLIF) {
+            parse_error(lineno_, ".param", "Supported only in extended BLIF format");
+        }
+    }
+
+         void end_model() override {}
+
+         void finish_parse() override {}
+
+         void parse_error(const int curr_lineno, const std::string& near_text, const   std::string& msg) override {
+              fprintf(stderr, "Custom Error at line %d near '%s': %s\n", curr_lineno,  near_text.c_str(), msg.c_str());
+              had_error_ = true;
+         }
+
+         bool had_error() { return had_error_ == true; }
+         std::vector<std::string> get_inputs() { return inputs_;}
+         std::vector<std::string> get_outputs() { return outputs_;}
+     private:
+         bool had_error_ = false;
+         std::vector<std::string> inputs_;
+         std::vector<std::string> outputs_;
+};
+
+// read port info from blif file
+bool BlifReader::read_blif(const std::string& blif_file_name)
+{
+    e_circuit_format circuit_format;
+    auto name_ext = vtr::split_ext(blif_file_name);
+    if (name_ext[1] == ".blif") {
+        circuit_format = e_circuit_format::BLIF;
+    } else if (name_ext[1] == ".eblif") {
+        circuit_format = e_circuit_format::EBLIF;
+    } else {
+        return false;
+    }
+    BlifParserCallback callback(circuit_format);
+    blif_parse_filename(blif_file_name, callback);
+    if (callback.had_error()) {
+        return false;
+    }
+    inputs = callback.get_inputs();
+    outputs = callback.get_outputs();
+    return true;
+}
+
+} // namespace pinc
+

--- a/pin_c/src/file_readers/blif_reader.h
+++ b/pin_c/src/file_readers/blif_reader.h
@@ -1,0 +1,44 @@
+#pragma once
+#ifndef __rs_file_readers_BLIF_READER_H
+#define __rs_file_readers_BLIF_READER_H
+
+#include <unordered_map>
+#include <map>
+
+#include "util/pinc_log.h"
+
+namespace pinc {
+
+using std::string;
+using std::vector;
+
+/*
+Supported PCF commands:
+
+* set_io  <net> <pad> - constrain a given <net> to a given physical <pad> in eFPGA pinout.
+* set_clk <pin> <net> - constrain a given global clock <pin> to a given <net>
+
+  Every tile where <net> is present will be constrained to use a given global clock.
+*/
+
+class BlifReader
+{
+  vector<string> inputs;
+  vector<string> outputs;
+
+public:
+  BlifReader() {}
+  BlifReader(const string& f)
+  {
+    read_blif(f);
+  }
+  bool read_blif(const string& f);
+
+  const vector<string>& get_inputs()const { return inputs; }
+  const vector<string>& get_outputs()const { return outputs; }
+};
+
+}
+
+#endif
+


### PR DESCRIPTION
Fixing regression Raptor/tests/tcl_examples/aes_decrypt_gate/
The test should be updated sometime later, blif in pin_c is really obsolete feature and will be removed.
