### PR TITLE
stars: check status of vpr init and error out if needed

### DIFF
--- a/stars/src/RS/rsOpts.cpp
+++ b/stars/src/RS/rsOpts.cpp
@@ -487,8 +487,7 @@ ret:
 // and2_gemini
 bool rsOpts::set_VPR_TC1() noexcept {
   lputs(" O-set_VPR_TC1: and2_gemini");
-  assert(argc_ > 0);
-  assert(argv_);
+  assert(argc_ > 0 && argv_);
 
 #ifdef RSBE_UNIT_TEST_ON
 
@@ -539,11 +538,9 @@ bool rsOpts::set_VPR_TC1() noexcept {
   return true;
 }
 
-// flop2flop
-bool rsOpts::set_VPR_TC2() noexcept {
-  lputs(" O-set_VPR_TC2: flop2flop");
-  assert(argc_ > 0);
-  assert(argv_);
+bool rsOpts::set_STA_TC2() noexcept {
+  lputs(" O-set_STA_TC2: arch 1GE100-ES1");
+  assert(argc_ > 0 && argv_);
 
 #ifdef RSBE_UNIT_TEST_ON
 
@@ -592,6 +589,82 @@ bool rsOpts::set_VPR_TC2() noexcept {
 #endif  // RSBE_UNIT_TEST_ON
 
   flush_out(true);
+  return true;
+}
+
+bool rsOpts::set_STA_TC3() noexcept {
+  lputs(" O-set_STA_TC3: flop2flop, arch GEMINI");
+  assert(argc_ > 0 && argv_);
+
+#ifdef RSBE_UNIT_TEST_ON
+
+  static const char* raw_TC3 = R"(
+    /home/serge/raps/10jul/Raptor/build/share/raptor/etc/devices/1GE100-ES1/gemini_vpr.xml
+    /home/serge/raps/10jul/Raptor/EDA-1704/stars_TC3/synth_1_1/synthesis/flop2flop_post_synth.v
+    --sdc_file /home/serge/raps/10jul/Raptor/EDA-1704/stars_TC3/impl_1_1/packing/flop2flop_openfpga.sdc
+    --route_chan_width 160 --suppress_warnings check_rr_node_warnings.log,check_rr_node
+    --clock_modeling ideal --absorb_buffer_luts off --skip_sync_clustering_and_routing_results off
+    --constant_net_method route --post_place_timing_report flop2flop_post_place_timing.rpt
+    --device castor104x68_heterogeneous --allow_unrelated_clustering on
+    --allow_dangling_combinational_nodes on --place_delta_delay_matrix_calculation_method dijkstra
+    --gen_post_synthesis_netlist on
+    --post_synth_netlist_unconn_inputs gnd
+    --inner_loop_recompute_divider 1 --max_router_iterations 1500
+    --timing_report_detail detailed --timing_report_npaths 100
+    --net_file /home/serge/raps/10jul/Raptor/EDA-1704/stars_TC3/impl_1_1/packing/flop2flop_post_synth.net
+    --place_file /home/serge/raps/10jul/Raptor/EDA-1704/stars_TC3/impl_1_1/placement/flop2flop_post_synth.place
+    --route_file /home/serge/raps/10jul/Raptor/EDA-1704/stars_TC3/impl_1_1/routing/flop2flop_post_synth.route
+    --place
+  )";
+
+  cout << '\n' << ::strlen(raw_TC3) << endl;
+
+  vector<string> W;
+  fio::Fio::split_spa(raw_TC3, W);
+
+  size_t sz = W.size();
+  cout << "W.size()= " << sz << endl;
+  if (sz < 3) return false;
+
+  cout << "created ARGV for VPR:" << endl;
+  for (size_t i = 0; i < sz; i++) {
+    lprintf("\t |%zu|  %s\n", i, W[i].c_str());
+  }
+
+  vprArgv_ = (char**)::calloc(sz + 4, sizeof(char*));
+  uint cnt = 0;
+  vprArgv_[cnt++] = ::strdup(argv_[0]);
+  for (size_t i = 0; i < sz; i++) {
+    const string& a = W[i];
+    vprArgv_[cnt++] = ::strdup(a.c_str());
+  }
+  vprArgc_ = cnt;
+
+#endif  // RSBE_UNIT_TEST_ON
+
+  flush_out(true);
+  return true;
+}
+
+bool rsOpts::createVprArgv(const vector<string>& W) noexcept {
+  size_t sz = W.size();
+  lout() << "W.size()= " << sz << endl;
+  if (sz < 3) return false;
+
+  lout() << "created ARGV for VPR:" << endl;
+  for (size_t i = 0; i < sz; i++) {
+    lprintf("\t |%zu|  %s\n", i, W[i].c_str());
+  }
+
+  vprArgv_ = (char**)::calloc(sz + 4, sizeof(char*));
+  uint cnt = 0;
+  vprArgv_[cnt++] = ::strdup(argv_[0]);
+  for (size_t i = 0; i < sz; i++) {
+    const string& a = W[i];
+    vprArgv_[cnt++] = ::strdup(a.c_str());
+  }
+  vprArgc_ = cnt;
+
   return true;
 }
 

--- a/stars/src/RS/rsOpts.h
+++ b/stars/src/RS/rsOpts.h
@@ -6,9 +6,8 @@
 
 namespace rsbe {
 
-inline void zFree(void* p) noexcept {
-  if (p) ::free(p);
-}
+using std::string;
+using std::vector;
 
 struct rsOpts {
   using CStr = const char*;
@@ -71,7 +70,10 @@ struct rsOpts {
   bool set_PINC_test() noexcept;
 
   bool set_VPR_TC1() noexcept;  // and2_gemini
-  bool set_VPR_TC2() noexcept;  // flop2flop
+  bool set_STA_TC2() noexcept;  // flop2flop, arch 1GE100-ES1
+  bool set_STA_TC3() noexcept;  // flop2flop, arch GEMINI
+
+  bool createVprArgv(const vector<string>& W) noexcept;
 
 private:
   bool sprintFiles(CStr subdir, CStr stem) noexcept;

--- a/stars/src/RS/sta_lib_writer.cpp
+++ b/stars/src/RS/sta_lib_writer.cpp
@@ -100,6 +100,9 @@ void sta_lib_writer::write_cell(std::ostream& os, const lib_cell& cell) {
         case ENABLE:
           enable_name = in_pin.name();
           break;
+        case INVALID_PIN_TYPE:
+          assert(0);
+          break;
       }
     }
 

--- a/stars/src/main.cpp
+++ b/stars/src/main.cpp
@@ -1,4 +1,4 @@
-static const char* _rsbe_VERSION_STR = "rsbe0035";
+static const char* _rsbe_VERSION_STR = "rsbe0036";
 
 #include "RS/rsEnv.h"
 #include "util/pinc_log.h"
@@ -24,6 +24,8 @@ using std::string;
 static rsEnv s_env;
 
 static bool do_stars(const rsOpts& opts, bool orig_args) {
+  uint16_t tr = ltrace();
+  auto& ls = lout();
   int argc;
   const char** argv;
   if (orig_args) {
@@ -40,7 +42,7 @@ static bool do_stars(const rsOpts& opts, bool orig_args) {
   }
 
   // call vpr to build design context
-  cout << "\nSTARS: Preparing design data ... " << endl;
+  ls << "\nSTARS: Preparing design data ... " << endl;
 
   // add --analysis if it's missing:
   char** vprArgv = (char**)calloc(argc + 4, sizeof(char*));
@@ -53,24 +55,33 @@ static bool do_stars(const rsOpts& opts, bool orig_args) {
     vprArgv[i] = strdup(a);
   }
   if (not found_analysis) {
-    cout << "STARS: added --analysis to vpr options" << endl;
+    ls << "STARS: added --analysis to vpr options" << endl;
     vprArgv[argc] = strdup("--analysis");
     vprArgc++;
   }
 
-  vpr4stars(vprArgc, vprArgv);
-
-  // write files for opensta
-  //
   bool status = true;
-  cout << "STARS: Creating sta files ... " << endl;
-  if (!create_sta_files(argc, argv)) {
-    lputs("\n[Error] STARS: Creating sta files failed.");
-    cerr << "[Error] STARS: Creating sta files failed." << endl;
-    status = false;
-  } else {
-    lputs("STARS: Creating sta files succeeded.");
-    status = true;
+  ls << "STARS: Initializing VPR data ... " << endl;
+
+  int vpr_code = vpr4stars(vprArgc, vprArgv);
+  if (tr >= 2)
+    lprintf("vpr4stars returned: %i\n", vpr_code);
+  if (vpr_code != 0) {
+      lputs("\n[Error] STARS: VPR init failed.");
+      cerr << "[Error] STARS: VPR init failed." << endl;
+      status = false;
+  }
+
+  if (status) {
+    ls << "STARS: Creating sta files ... " << endl;
+    if (!create_sta_files(argc, argv)) {
+      lputs("\n[Error] STARS: Creating sta files failed.");
+      cerr << "[Error] STARS: Creating sta files failed." << endl;
+      status = false;
+    } else {
+      lputs("STARS: Creating sta files succeeded.");
+      status = true;
+    }
   }
 
   return status;
@@ -155,7 +166,7 @@ int main(int argc, char** argv) {
   bool rsbe_builtin_VPR_TC = getenv("rsbe_builtin_VPR_TC");
   if (rsbe_builtin_STA_TC) {
     lputs("\n(rsbe_builtin_STA_TC)\n");
-    ok = opts.set_VPR_TC2();
+    ok = opts.set_STA_TC3();
     if (ok) {
       ok = do_stars(opts, false);
       if (ok) {
@@ -165,7 +176,7 @@ int main(int argc, char** argv) {
     }
   } else if (rsbe_builtin_VPR_TC) {
     lputs("\n(rsbe_builtin_VPR_TC)\n");
-    ok = opts.set_VPR_TC2();
+    ok = opts.set_VPR_TC1();
     if (ok) {
       status = do_vpr(opts);
       lprintf("DID vpr. status= %i\n", status);


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To address an existing issue. If so, please provide a link to the issue: <issue id>
> - [X ] Breaking new feature. If so, please describe details in the description part.

stars: check status of vpr init and error out if needed.
In case of problems with input files (say, verilog file is missing), VPR init code returns error status.
Previously, stars did not check VPR status which resulted in a crash in case of missing files.