### PR TITLE
EDA-1727: stars: correct arc-type for check arcs in .lib

### DIFF
--- a/stars/src/RS/WriterVisitor.cpp
+++ b/stars/src/RS/WriterVisitor.cpp
@@ -219,13 +219,13 @@ void StaWriterVisitor::print_lib(int depth) {
   lib_pin pin_in;
   pin_in.setName("datain");
   pin_in.bus_width(1);
-  pin_in.direction(INPUT);
+  pin_in.setDirection(INPUT);
   pin_in.setType(DATA);
-  cell.add_pin(pin_in, INPUT);
+  cell.add_input(pin_in);
   lib_pin pin_out;
   pin_out.setName("dataout");
   pin_out.bus_width(1);
-  pin_out.direction(OUTPUT);
+  pin_out.setDirection(OUTPUT);
   pin_out.setType(DATA);
 
   TimingArc arc;
@@ -234,7 +234,7 @@ void StaWriterVisitor::print_lib(int depth) {
   arc.setRelatedPin(pin_in);
 
   pin_out.add_timing_arc(arc);
-  cell.add_pin(pin_out, OUTPUT);
+  cell.add_output(pin_out);
   lib_writer.write_lcell(lib_os_, cell);
   written_cells.insert("fpga_interconnect");
 

--- a/stars/src/RS/rsDB.cpp
+++ b/stars/src/RS/rsDB.cpp
@@ -173,12 +173,12 @@ void LutInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
 
   lib_pin pin_in;
   pin_in.setName("in");
-  pin_in.direction(INPUT);
+  pin_in.setDirection(INPUT);
   pin_in.bus_width(in_bus_width);
-  cell.add_pin(pin_in, INPUT);
+  cell.add_input(pin_in);
   lib_pin pin_out;
   pin_out.setName("out");
-  pin_out.direction(OUTPUT);
+  pin_out.setDirection(OUTPUT);
 
   TimingArc arc;
   arc.setSense(POSITIVE);
@@ -187,7 +187,7 @@ void LutInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
 
   pin_out.add_timing_arc(arc);
   pin_out.bus_width(out_bus_width);
-  cell.add_pin(pin_out, OUTPUT);
+  cell.add_output(pin_out);
 
   lib_writer.write_lcell(os, cell);
 }
@@ -343,7 +343,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
       if (written_in_pins.find(pin_name) == written_in_pins.end()) {
         related_pin.setName(pin_name);
         related_pin.bus_width(1);
-        related_pin.direction(INPUT);
+        related_pin.setDirection(INPUT);
         related_pin.setType(CLOCK);
         written_in_pins.insert(std::pair<string, lib_pin>(pin_name, related_pin));
       } else {
@@ -362,7 +362,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         if (written_out_pins.find(out_pin_name) == written_out_pins.end()) {
           pin_out.setType(DATA);
           pin_out.setName(out_pin_name);
-          pin_out.direction(OUTPUT);
+          pin_out.setDirection(OUTPUT);
           pin_out.bus_width(1);
           written_out_pins.insert(std::pair<string, lib_pin>(out_pin_name, pin_out));
         } else {
@@ -387,7 +387,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
       if (written_in_pins.find(pin_name) == written_in_pins.end()) {
         related_pin.setName(pin_name);
         related_pin.bus_width(1);
-        related_pin.direction(INPUT);
+        related_pin.setDirection(INPUT);
         related_pin.setType(CLOCK);
         written_in_pins.insert(std::pair<string, lib_pin>(pin_name, related_pin));
       } else {
@@ -405,7 +405,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         if (written_in_pins.find(in_pin_name) == written_in_pins.end()) {
           pin_in.setName(in_pin_name);
           pin_in.bus_width(1);
-          pin_in.direction(INPUT);
+          pin_in.setDirection(INPUT);
           pin_in.setType(DATA);
           written_in_pins.insert(std::pair<string, lib_pin>(in_pin_name, pin_in));
         } else {
@@ -428,7 +428,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
       if (written_in_pins.find(pin_name) == written_in_pins.end()) {
         related_pin.setName(pin_name);
         related_pin.bus_width(1);
-        related_pin.direction(INPUT);
+        related_pin.setDirection(INPUT);
         related_pin.setType(CLOCK);
         written_in_pins.insert(std::pair<string, lib_pin>(pin_name, related_pin));
       } else {
@@ -446,7 +446,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         if (written_in_pins.find(in_pin_name) == written_in_pins.end()) {
           pin_in.setName(in_pin_name);
           pin_in.bus_width(1);
-          pin_in.direction(INPUT);
+          pin_in.setDirection(INPUT);
           pin_in.setType(DATA);
           written_in_pins.insert(std::pair<string, lib_pin>(in_pin_name, pin_in));
         } else {
@@ -462,13 +462,11 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
     }
 
     // add pins to cell
-    for (std::map<string, lib_pin>::iterator itr = written_in_pins.begin(); itr != written_in_pins.end();
-         itr++) {
-      cell.add_pin(itr->second, INPUT);
+    for (auto I = written_in_pins.cbegin(); I != written_in_pins.cend(); ++I) {
+      cell.add_input(I->second);
     }
-    for (std::map<string, lib_pin>::iterator itr = written_out_pins.begin(); itr != written_out_pins.end();
-         itr++) {
-      cell.add_pin(itr->second, OUTPUT);
+    for (auto I = written_out_pins.cbegin(); I != written_out_pins.cend(); ++I) {
+      cell.add_output(I->second);
     }
   } else if (!timing_arcs_.empty()) {
     // just write out timing arcs
@@ -483,7 +481,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         lib_pin pin_in;
         pin_in.setName(in_pin_name);
         pin_in.bus_width(1);
-        pin_in.direction(INPUT);
+        pin_in.setDirection(INPUT);
         pin_in.setType(DATA);
         // cell.add_pin(pin_in, INPUT);
         written_in_pins.insert(std::pair<string, lib_pin>(in_pin_name, pin_in));
@@ -503,7 +501,7 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         lib_pin pin_out;
         pin_out.setName(out_pin_name);
         pin_out.bus_width(1);
-        pin_out.direction(OUTPUT);
+        pin_out.setDirection(OUTPUT);
         pin_out.setType(DATA);
         pin_out.add_timing_arc(tarc);
         // cell.add_pin(pin_out, OUTPUT);
@@ -512,13 +510,11 @@ void BlackBoxInst::print_lib(rsbe::LibWriter& lib_writer, ostream& os) {
         written_out_pins[out_pin_name].add_timing_arc(tarc);
       }
     }
-    for (std::map<string, lib_pin>::iterator itr = written_in_pins.begin(); itr != written_in_pins.end();
-         itr++) {
-      cell.add_pin(itr->second, INPUT);
+    for (auto I = written_in_pins.cbegin(); I != written_in_pins.cend(); ++I) {
+      cell.add_input(I->second);
     }
-    for (std::map<string, lib_pin>::iterator itr = written_out_pins.begin(); itr != written_out_pins.end();
-         itr++) {
-      cell.add_pin(itr->second, OUTPUT);
+    for (auto I = written_out_pins.cbegin(); I != written_out_pins.cend(); ++I) {
+      cell.add_output(I->second);
     }
   } else {
     std::cerr << "STARS: NYI - Create cell for blackbox.\n";

--- a/stars/src/RS/sta_lib_data.h
+++ b/stars/src/RS/sta_lib_data.h
@@ -29,15 +29,17 @@ using std::string;
 using std::vector;
 using namespace pinc;
 
-enum port_direction_type { INPUT = 0, OUTPUT, INVALID_DIR };
+enum Port_direction_type { INPUT = 0, OUTPUT, INVALID_DIR };
 
-enum timing_sense_type { POSITIVE = 0, NEGATIVE, INVALID_SENSE };
+enum Timing_sense_type { POSITIVE = 0, NEGATIVE, INVALID_SENSE };
 
-enum pin_type { DATA = 0, CLOCK, RESET, SET, ENABLE, INVALID_PIN_TYPE };
+enum Pin_type { DATA = 0, CLOCK, RESET, SET, ENABLE, INVALID_PIN_TYPE };
 
-enum Timing_type_type { TRANSITION = 0, SETUP, HOLD };
+enum Timing_arc_type { TRANSITION = 0, SETUP, HOLD };
 
 enum Cell_type { INTERCONNECT = 0, LUT, BRAM, DSP, SEQUENTIAL, BLACKBOX, INVALID_CELL };
+
+//const char* str_Pin_type(Pin_type t) noexcept;
 
 class TimingArc;
 
@@ -45,45 +47,43 @@ class lib_pin {
 private:
   string name_;
   int bus_width_ = 0;
-  port_direction_type dir_ = INPUT;
-  pin_type pin_type_ = DATA;
-  vector<TimingArc> timing_arch_list_;
+  Port_direction_type dir_ = INPUT;
+  Pin_type pin_type_ = DATA;
+  vector<TimingArc> timing_arcs_;
 
 public:
-  lib_pin() = default;
+  lib_pin() noexcept = default;
 
   const string& name() const noexcept { return name_; }
   void setName(const string& name) noexcept { name_ = name; }
 
   int bus_width() const noexcept { return bus_width_; }
-  void bus_width(int value) { bus_width_ = value; }
+  void bus_width(int value) noexcept { bus_width_ = value; }
 
-  port_direction_type direction() const noexcept { return dir_; }
-  void direction(port_direction_type value) { dir_ = value; }
+  Port_direction_type direction() const noexcept { return dir_; }
+  void setDirection(Port_direction_type value) noexcept { dir_ = value; }
 
-  pin_type type() const noexcept { return pin_type_; }
-  void setType(pin_type value) noexcept { pin_type_ = value; }
+  Pin_type type() const noexcept { return pin_type_; }
+  void setType(Pin_type value) noexcept { pin_type_ = value; }
 
-  void add_timing_arc(TimingArc& arch) noexcept {
-    timing_arch_list_.push_back(arch);
-  }
-  const vector<TimingArc>& get_timing_arcs() const noexcept { return timing_arch_list_; }
+  void add_timing_arc(const TimingArc& arch) noexcept { timing_arcs_.push_back(arch); }
+  const vector<TimingArc>& get_timing_arcs() const noexcept { return timing_arcs_; }
 };
 
 class TimingArc {
 private:
-  timing_sense_type sense_ = POSITIVE;
-  Timing_type_type type_ = TRANSITION;
+  Timing_sense_type sense_ = POSITIVE;
+  Timing_arc_type type_ = TRANSITION;
   lib_pin related_pin_;
 
 public:
   TimingArc() = default;
 
-  timing_sense_type sense() const noexcept { return sense_; }
-  void setSense(timing_sense_type value) noexcept { sense_ = value; }
+  Timing_sense_type sense() const noexcept { return sense_; }
+  void setSense(Timing_sense_type value) noexcept { sense_ = value; }
 
-  Timing_type_type type() const noexcept { return type_; }
-  void setType(Timing_type_type value) noexcept { type_ = value; }
+  Timing_arc_type type() const noexcept { return type_; }
+  void setType(Timing_arc_type value) noexcept { type_ = value; }
 
   lib_pin related_pin() const noexcept { return related_pin_; }
   void setRelatedPin(lib_pin value) noexcept { related_pin_ = value; }
@@ -108,46 +108,22 @@ public:
   const vector<lib_pin>& get_inputs() const noexcept { return input_pins_; }
   const vector<lib_pin>& get_outputs() const noexcept { return output_pins_; }
 
-/*
-  const vector<lib_pin>& get_pins(port_direction_type dir) const {
-    if (dir == INPUT) {
-      return input_pins_;
-    } else if (dir == OUTPUT) {
-      return output_pins_;
-    } else {
-      std::cerr << "[STARS] Reject returning invalid pin." << std::endl;
-    }
-    return null_pins;
-  }
-*/
+  void add_input(const lib_pin& pin) noexcept { input_pins_.push_back(pin); }
+  void add_output(const lib_pin& pin) noexcept { output_pins_.push_back(pin); }
 
-  void add_pin(const lib_pin& pin, port_direction_type dir) {
+/*
+  void add_pin(const lib_pin& pin, Port_direction_type dir) noexcept {
     if (dir == INPUT) {
       input_pins_.push_back(pin);
     } else if (dir == OUTPUT) {
       output_pins_.push_back(pin);
     } else {
-      std::cerr << "[STARS] Reject adding invalid pin." << std::endl;
+      std::cout << "[Error] [STARS] Reject adding invalid pin." << std::endl;
+      std::cerr << "[Error] [STARS] Reject adding invalid pin." << std::endl;
+      assert(0);
     }
   }
-
-  /*
-  lib_pin &get_pin_by_name(string name) {
-    for (auto pin : input_pins_) {
-      if (pin.name() == name) {
-        return pin;
-      }
-    }
-    for (auto pin : output_pins_) {
-      if (pin.name() == name) {
-        return pin;
-      }
-    }
-    null_pin = new lib_pin;
-    null_pin.direction(INVALID_DIR);
-    return null_pin;
-  }
-  */
+*/
 };
 
 }  // end namespace rsbe

--- a/stars/src/RS/sta_lib_writer.h
+++ b/stars/src/RS/sta_lib_writer.h
@@ -37,7 +37,7 @@ public:
 
   void write_lcell_pins(std::ostream& os, const lib_cell& lc) const;
 
-  void write_timing_relation(std::ostream& os, const TimingArc& timing) const;
+  void write_timing_arc(std::ostream& os, const lib_pin& basePin, const TimingArc& arc) const;
 
   void write_footer(std::ostream& os) const;
 };


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ X] To address an existing issue. If so, please provide a link to the issue: <EDA-1727>
> - [ ] Breaking new feature. If so, please describe details in the description part.

Corrected the timing arc type for check-arcs (setup/hold).
