### PR TITLE
EDA-1828: temporarily disabled prune_verilog() call

### DIFF
--- a/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.cpp
+++ b/include/read_verilog/OpenFPGA/vpr/src/base/read_blif.cpp
@@ -784,7 +784,7 @@ AtomNetlist read_blif_from_vrilog(e_circuit_format circuit_format,
     std::string blif_file_ = blif_file;
 
     gb_constructs gb;
-    prune_verilog(blif_file, gb);
+    // TEMPORARILY disabled: EDA-1828  prune_verilog(blif_file, gb);
     if (gb.contains_io_prem) {
         mod_str = gb.mod_str;
         blif_file_.insert(blif_file_.find_last_of("."), "_"); // Insert underscore before the file extension


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ X] To address an existing issue. If so, please provide a link to the issue: EDA-1828
