### PR TITLE
added TBB lib linkage

### DIFF
--- a/include/read_verilog/OpenFPGA/vpr/CMakeLists.txt
+++ b/include/read_verilog/OpenFPGA/vpr/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 #Configure the build to use the selected engine
 if (VPR_USE_EXECUTION_ENGINE STREQUAL "tbb")
     target_compile_definitions(libvpr PRIVATE VPR_USE_TBB)
-    target_link_libraries(libvpr tbb)
+    target_link_libraries(libvpr ${TBB_LIBRARIES})
     target_link_libraries(libvpr ${TBB_tbbmalloc_proxy_LIBRARY}) #Use the scalable memory allocator
     message(STATUS "VPR: will support parallel execution using '${VPR_USE_EXECUTION_ENGINE}'")
 elseif(VPR_USE_EXECUTION_ENGINE STREQUAL "serial")


### PR DESCRIPTION
A change on Raptor Level with MtKahyPar coming as a submodule of Raptor_Tools libtbb version 2021 will be available. libtbb is a must for MtKahPar so at the Raptor level, find_package will know where it is and will supply it. This change keeps both vpr and MtKahPar on the same page in terms of finding libtbb libs otherwise they will end up using different versions of libtbb.