### PR TITLE
Putting the module name dffxxx to upper for verilog only post P&R

### DIFF
--- a/include/read_verilog/OpenFPGA/vpr/src/base/netlist_writer.cpp
+++ b/include/read_verilog/OpenFPGA/vpr/src/base/netlist_writer.cpp
@@ -689,6 +689,10 @@ public:
                                      // for verilog only
       mod_name = "ADDER_CARRY";
     }
+    if (mod_name.find("dff") == 0) {
+      std::transform(mod_name.begin(), mod_name.end(), mod_name.begin(),
+                     ::toupper);
+    }
     os << indent(depth) << mod_name << " #(\n";
 
     // Verilog parameters


### PR DESCRIPTION
> ### Motivate of the pull request
> - [ ] To put dffxxx to uppercase after P&R