### PR TITLE
skip empty string in eblif transform

### DIFF
--- a/include/eblif_tranform/transform_blif.h
+++ b/include/eblif_tranform/transform_blif.h
@@ -348,6 +348,9 @@ public:
 
     std::string line;
     while (std::getline(ifs, line)) {
+      if (line.empty()) {
+        continue;
+      }
       std::string ln(line);
       while ('\\' == ln.back() && std::getline(ifs, line)) {
         ln.pop_back();


### PR DESCRIPTION
string::back() is undefined if the string is empty.
Crashes in debug-compiled vpr.
