### PR TITLE
Remove the name of left employee from Update OpenFPGA bot YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     # must use the full team name, including the organization, as if you were @mentioning the team
     reviewers:
       - "alain-rs"
-      - "behnam-rs"
       - "ManadherRS"
       - "behzadmehmood-rs"
       - "umariqbal-rs"


### PR DESCRIPTION
Remove the user name of the left employee from the Update OpenFPGA bot YAML 